### PR TITLE
Fixed shared variable declaration; clang was not compiling this

### DIFF
--- a/CoMDLib/CoMD_lib.c
+++ b/CoMDLib/CoMD_lib.c
@@ -25,6 +25,8 @@
 
 #include "CoMD_lib.h"
 
+FILE* stressOut;
+
 #define REDIRECT_OUTPUT 0
 #define   MIN(A,B) ((A) < (B) ? (A) : (B))
 

--- a/CoMDLib/deformation.h
+++ b/CoMDLib/deformation.h
@@ -4,7 +4,7 @@
 #include "CoMDTypes.h"
 #include "CoMD_lib.h"
 
-FILE* stressOut;
+extern FILE* stressOut;
 
 CoMD_return printTensor(int step, real_t* mat9);
 void matVec3(real_t *mat, real_t *vec);


### PR DESCRIPTION
Hello,

I am trying to compile CoMDLib (and CoHMM) using clang. I have no problem with gcc. The declaration of the FILE* stressOut shared variable used in deformation.c and CoMD_lib.c is causing an error at link time:

```
clang  cohmm.c -ICoMDLib -LCoMDLib -lCoMD -lm -g -O3 -o cohmm
CoMDLib/libCoMD.a(deformation.o):(.bss+0x0): multiple definition of `stressOut'
CoMDLib/libCoMD.a(CoMD_lib.o):(.bss+0x0): first defined here
CoMDLib/libCoMD.a(timestep.o):(.bss+0x0): multiple definition of `stressOut'
CoMDLib/libCoMD.a(CoMD_lib.o):/storage/users/coti/x86/CoHMM/CoMDLib/CoMD_lib.c:57: first defined here
clang-14: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [cohmm] Error 1
```

We simply need to declare it as extern in the header file and declare it once, for instance in CoMD_lib.c. Here is my patch.
